### PR TITLE
fix(entry-state): detect draft and pending changes at the same time

### DIFF
--- a/lib/entry-state.js
+++ b/lib/entry-state.js
@@ -13,10 +13,13 @@ module.exports = async function attachEntryState (entry) {
   const publishedEntry = await getPublishedEntry(entry)
   entry.draft = false
   entry.pendingChanges = false
+
+  // If there is no published version, it is a draft and can't have pending changes
   if (!publishedEntry) {
     entry.draft = true
     return entry
   }
+
   // We group fields of type link (i.e. Only objects/array) from the same entry in preview and delivery
   const entriesToCompare = Object.keys(entry.fields).map((key) => {
     const field = entry.fields[key]
@@ -31,28 +34,31 @@ module.exports = async function attachEntryState (entry) {
     // If the field is an array of reference we need to check its item if they have pending changes
     if (isArray(originalItem)) {
       originalItem.forEach((innerItem, index) => {
-        if (!isArray(innerItem) && isLinkDraft(innerItem, publishedItem[index])) {
-          entry.pendingChanges = true
+        if (!isArray(innerItem)) {
+          setEntryState(entry, innerItem, publishedItem[index])
           return
         }
       })
+    } else {
       // If the field is a single reference we just check if it has pending changes
-    } else if (isLinkDraft(item[0], item[1])) {
-      entry.pendingChanges = true
-      return entry
+      setEntryState(entry, originalItem, publishedItem)
     }
   })
   // We check if the root element has pending changes
-  if (entry && publishedEntry && (entry.sys.updatedAt !== publishedEntry.sys.updatedAt)) {
-    entry.pendingChanges = true
+  if (entry && publishedEntry) {
+    setEntryState(entry, entry, publishedEntry)
   }
 
   return entry
 }
 
 function isLinkDraft (previewLink, deliveryLink) {
-  if (isObject(previewLink)) {
-    return !previewLink.fields || !isDateEqual(previewLink.sys.updatedAt, previewLink.sys.updatedAt)
+  return previewLink && !deliveryLink
+}
+
+function isLinkPendingChanges (previewLink, deliveryLink) {
+  if (previewLink && deliveryLink) {
+    return !isDateEqual(previewLink.sys.updatedAt, deliveryLink.sys.updatedAt)
   }
   return false
 }
@@ -63,3 +69,12 @@ function isDateEqual (lhs, rhs) {
   return lhsDate.setMilliseconds(0) === rhsDate.setMilliseconds(0)
 }
 
+function setEntryState (entry, originalItem, publishedItem) {
+  if (isLinkDraft(originalItem, publishedItem)) {
+    entry.draft = true
+  }
+  if (isLinkPendingChanges(originalItem, publishedItem)) {
+    entry.pendingChanges = true
+  }
+  return entry
+}

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "body-parser": "~1.15.2",
-    "contentful": "^5.0.2",
+    "contentful": "^5.1.1",
     "cookie-parser": "~1.4.3",
     "dotenv": "^4.0.0",
     "execa": "^0.8.0",

--- a/services/contentful.js
+++ b/services/contentful.js
@@ -28,7 +28,8 @@ module.exports.initClients = (options) => {
     accessToken: config.deliveryToken,
     // Environment variable is used here to enable testing this app internally at Contentful.
     // You can just omit the host since it defaults to 'cdn.contentful.com'
-    host: process.env.CONTENTFUL_DELIVERY_API_HOST
+    host: process.env.CONTENTFUL_DELIVERY_API_HOST,
+    removeUnresolved: true
   })
   previewClient = createClient({
     application: applicationName,
@@ -36,7 +37,8 @@ module.exports.initClients = (options) => {
     accessToken: config.previewToken,
     // Environment variable is used here to enable testing this app internally at Contentful.
     // You should use 'preview.contentful.com' as host to use the preview api
-    host: process.env.CONTENTFUL_PREVIEW_API_HOST
+    host: process.env.CONTENTFUL_PREVIEW_API_HOST,
+    removeUnresolved: true
   })
 }
 

--- a/views/mixins/_editorialFeatures.pug
+++ b/views/mixins/_editorialFeatures.pug
@@ -4,8 +4,7 @@ mixin editorialFeatures(entry)
   if settings.editorialFeatures
     .editorial-features
       if currentApi.id === 'cpa' && (entry.draft || entry.pendingChanges)
-        .editorial-features__item
-          +entryState(entry)
+        +entryState(entry)
       .editorial-features__item
         a.editorial-features__text(
           href=`https://app.contentful.com/spaces/${settings.spaceId}/entries/${entry.sys.id}`

--- a/views/mixins/_entryState.pug
+++ b/views/mixins/_entryState.pug
@@ -1,5 +1,7 @@
 mixin entryState(entry)
   if entry.draft
-    .pill.pill--draft #{translate('draftLabel', currentLocale.code)}
+    .editorial-features__item
+      .pill.pill--draft #{translate('draftLabel', currentLocale.code)}
   if entry.pendingChanges
-    .pill.pill--pending-changes #{translate('pendingChangesLabel', currentLocale.code)}
+    .editorial-features__item
+      .pill.pill--pending-changes #{translate('pendingChangesLabel', currentLocale.code)}


### PR DESCRIPTION
Rewrites entry state detection to be able to detect drafts & pending changes at the same time.

relies on https://github.com/contentful/contentful.js/pull/226