### PR TITLE
Changed Dockerfile to use alpine image (smaller)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,12 @@
-FROM node:9
+FROM mhart/alpine-node:14
 
 WORKDIR /app
-
-RUN npm install -g contentful-cli
-
-COPY package.json .
-RUN npm install
-
 COPY . .
 
+RUN npm ci --prod
+
 USER node
+
 EXPOSE 3000
 
-CMD ["npm", "run", "start:dev"]
+CMD [ "npm", "run", "start:dev" ]


### PR DESCRIPTION
So I found [this]((https://github.com/mhart/alpine-node)) base image for node using alpine Linux which results in much smaller images. In this case, the current Dockerfile I built resulted on a 800MB image and the one I'm submitting now results on a 130MB image. As far as I've tested, it's working just as well (but I did drop out the contentful-cli install).